### PR TITLE
pre-commit update action - change committer and author

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -67,3 +67,6 @@
 - name: skip-changelog
   description: This will not be added to release notes
   color: "dddddd"
+- name: pre-commit
+  description: Pull requests that update pre-commit code
+  color: "424242"

--- a/.github/workflows/precommit-update.yml
+++ b/.github/workflows/precommit-update.yml
@@ -22,4 +22,10 @@ jobs:
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
+          committer: "dependabot[bot] <support@github.com>"
+          author: "dependabot[bot] <support@github.com>"
+          signoff: true
+          labels: |
+            dependencies
+            pre-commit
           body: Update versions of pre-commit hooks to latest version.


### PR DESCRIPTION
Hi! I've added committer and author fields in pre-commit change. I hope this will work and show `dependabot` with next update.
@staticdev please take a look.