### PR TITLE
Revert "Change pre-commit updater committer to different dependabot email"

### DIFF
--- a/.github/workflows/precommit-update.yml
+++ b/.github/workflows/precommit-update.yml
@@ -24,7 +24,7 @@ jobs:
           branch: update/pre-commit-hooks
           title: Update pre-commit hooks
           commit-message: "chore: update pre-commit hooks"
-          committer: "dependabot[bot] <support@github.com>"
+          committer: "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>"
           author: "dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>"
           signoff: true
           labels: |


### PR DESCRIPTION
Hi @staticdev it seems, that it wasn't the root cause, so I'm reverting it, as the previous code returned proper author and commiter (dependabot).

Reverts nextcloud/ansible-collection-nextcloud-admin#232