### PR TITLE
Cleanup unnecessary block statement in nc-apps.ymls.

### DIFF
--- a/roles/install_nextcloud/tasks/nc_apps.yml
+++ b/roles/install_nextcloud/tasks/nc_apps.yml
@@ -5,57 +5,55 @@
     nc_app_source: "{{ item.value.source if item.value.source is defined else item.value }}"
     nc_app_cfg: "{{ item.value }}"
 
-- name: "[App] - Download, install, enable and if provided configure Nextcloud Apps"
-  block:
-    - name: "[App] - Verify the yaml declaration for the app \"{{ nc_app_name }}\""
-      ansible.builtin.assert:
-        that:
-          - (nc_app_cfg.source is defined) and (nc_app_cfg.source is string)
-        msg: "{{ nc_app_name }} is not well declared."
-      when: nc_app_cfg is not string
+- name: "[App] - Verify the yaml declaration for the app \"{{ nc_app_name }}\""
+  ansible.builtin.assert:
+    that:
+      - (nc_app_cfg.source is defined) and (nc_app_cfg.source is string)
+    msg: "{{ nc_app_name }} is not well declared."
+  when: nc_app_cfg is not string
 
-    - name: "[App] - Install from the official app-store app: \"{{ nc_app_name }}\""
-      become_user: "{{ nextcloud_websrv_user }}"
-      become_flags: "{{ ansible_become_flags | default(omit) }}"
-      become: true
-      ansible.builtin.command: php occ app:install "{{ nc_app_name }}"
-      args:
-        chdir: "{{ nextcloud_webroot }}"
-      when: (nc_app_source is string) and (nc_app_source | length == 0)
-      register: output
-      changed_when: "output.rc == 0"
+- name: "[App] - Install from the official app-store app: \"{{ nc_app_name }}\""
+  become_user: "{{ nextcloud_websrv_user }}"
+  become_flags: "{{ ansible_become_flags | default(omit) }}"
+  become: true
+  ansible.builtin.command: php occ app:install "{{ nc_app_name }}"
+  args:
+    chdir: "{{ nextcloud_webroot }}"
+  when: (nc_app_source is string) and (nc_app_source | length == 0)
+  register: output
+  changed_when: "output.rc == 0"
 
-    - name: "[App] - Download Archive in apps folder from \"{{ nc_app_source }}\""
-      become_user: "{{ nextcloud_websrv_user }}"
-      become_flags: "{{ ansible_become_flags | default(omit) }}"
-      ansible.builtin.unarchive:
-        copy: false
-        src: "{{ nc_app_source }}"
-        dest: "{{ nextcloud_webroot }}/apps/"
-        owner: "{{ nextcloud_websrv_user }}"
-        group: "{{ nextcloud_websrv_group }}"
-        creates: "{{ nextcloud_webroot }}/apps/{{ nc_app_name }}"
-      when: (nc_app_source is string) and (nc_app_source | length > 0)
+- name: "[App] - Download Archive in apps folder from \"{{ nc_app_source }}\""
+  become_user: "{{ nextcloud_websrv_user }}"
+  become_flags: "{{ ansible_become_flags | default(omit) }}"
+  ansible.builtin.unarchive:
+    copy: false
+    src: "{{ nc_app_source }}"
+    dest: "{{ nextcloud_webroot }}/apps/"
+    owner: "{{ nextcloud_websrv_user }}"
+    group: "{{ nextcloud_websrv_group }}"
+    creates: "{{ nextcloud_webroot }}/apps/{{ nc_app_name }}"
+  when: (nc_app_source is string) and (nc_app_source | length > 0)
 
-    - name: "[App] - Enable the application \"{{ nc_app_name }}\""
-      become_user: "{{ nextcloud_websrv_user }}"
-      become_flags: "{{ ansible_become_flags | default(omit) }}"
-      become: true
-      ansible.builtin.command: php occ app:enable "{{ nc_app_name }}"
-      args:
-        chdir: "{{ nextcloud_webroot }}"
-      changed_when: true
+- name: "[App] - Enable the application \"{{ nc_app_name }}\""
+  become_user: "{{ nextcloud_websrv_user }}"
+  become_flags: "{{ ansible_become_flags | default(omit) }}"
+  become: true
+  ansible.builtin.command: php occ app:enable "{{ nc_app_name }}"
+  args:
+    chdir: "{{ nextcloud_webroot }}"
+  changed_when: true
 
-    - name: "[App] - Configure the application \"{{ nc_app_name }}\""
-      become_user: "{{ nextcloud_websrv_user }}"
-      become_flags: "{{ ansible_become_flags | default(omit) }}"
-      become: true
-      ansible.builtin.command: php occ config:app:set {{ nc_app_name }} {{ item_cfg.key }} --value="{{ item_cfg.value }}"
-      args:
-        chdir: "{{ nextcloud_webroot }}"
-      with_dict: "{{ nc_app_cfg.conf | default({}) }}"
-      loop_control:
-        loop_var: item_cfg
-      when: nc_app_cfg.conf is defined
-      register: output
-      changed_when: "output.rc == 0"
+- name: "[App] - Configure the application \"{{ nc_app_name }}\""
+  become_user: "{{ nextcloud_websrv_user }}"
+  become_flags: "{{ ansible_become_flags | default(omit) }}"
+  become: true
+  ansible.builtin.command: php occ config:app:set {{ nc_app_name }} {{ item_cfg.key }} --value="{{ item_cfg.value }}"
+  args:
+    chdir: "{{ nextcloud_webroot }}"
+  with_dict: "{{ nc_app_cfg.conf | default({}) }}"
+  loop_control:
+    loop_var: item_cfg
+  when: nc_app_cfg.conf is defined
+  register: output
+  changed_when: "output.rc == 0"


### PR DESCRIPTION
This is a simple cleanup. It removes an unnecessary block-statement that has remained. The mainy changes it suggests to include are only removal of leading spaces for correct indentation.