### PR TITLE
Add required ansible-utils for webserver settings

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,7 @@
 ---
+collections:
+  - name: ansible.utils
+    version: 2.9.0
 roles:
   - name: geerlingguy.php-versions
     version: 5.0.1


### PR DESCRIPTION
This collection is needed to manage: `nextcloud_trusted_domain` variable which is used in both Apache2 and Nginx configurations.