### PR TITLE
Temporary ignore ansible-lint var-naming[no-role-prefix]

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,3 @@
+---
+skip_list:
+  - var-naming[no-role-prefix]


### PR DESCRIPTION
This error started with last update of ansible-lint. It triggers more than 80 errors. I am adding this ignore until we fix it.