### PR TITLE
Fix a bug in nc_apache2.j2 template concerning intermed-CA. Remove an…

### DIFF
--- a/roles/install_nextcloud/tasks/tls_installed.yml
+++ b/roles/install_nextcloud/tasks/tls_installed.yml
@@ -7,7 +7,7 @@
   ansible.builtin.set_fact:
     nextcloud_tls_cert_key_file: "{{ nextcloud_tls_cert_key }}"
 
-- name: "[INSTALLED TLS] - Define certificate chain  path"
+- name: "[INSTALLED TLS] - Define certificate chain path"
   ansible.builtin.set_fact:
-    nextcloud_tls_cert_chain_file: "{{ nextcloud_tls_cert_chain }}"
+    nextcloud_tls_chain_file: "{{ nextcloud_tls_cert_chain }}"
   when: nextcloud_tls_cert_chain is defined

--- a/roles/install_nextcloud/tasks/tls_signed.yml
+++ b/roles/install_nextcloud/tasks/tls_signed.yml
@@ -54,5 +54,5 @@
     src: "{{ nextcloud_tls_src_cert_key }}"
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
-    mode: u=r,g=-,o=-
+    mode: 0400
     force: false

--- a/roles/install_nextcloud/tasks/tls_signed.yml
+++ b/roles/install_nextcloud/tasks/tls_signed.yml
@@ -12,13 +12,13 @@
     nextcloud_tls_chain_file: "{{ nextcloud_tls_chain_file | default(cert_path + nextcloud_instance_name + \".pem\") }}"
   when: nextcloud_tls_src_chain is defined
 
-- name: "[SIGNED TLS] - Copy certificate to the host"
+- name: "[SIGNED TLS] - Copy certificate file for apache2 to the host"
   ansible.builtin.copy:
     dest: "{{ nextcloud_tls_cert_file }}"
     src: "{{ nextcloud_tls_src_cert }}"
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
-    mode: "0640"
+    mode: u=rw,g=r,o=-
     force: true
   when:
     - nextcloud_websrv not in ["nginx"]
@@ -29,12 +29,24 @@
     dest: "{{ nextcloud_tls_cert_file }}"
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
-    mode: "0640"
+    mode: u=rw,g=r,o=-
   vars:
     input_files: ["{{ nextcloud_tls_src_cert }}", "{{ nextcloud_tls_src_chain }}"]
   when:
     - nextcloud_tls_src_chain is defined
     - nextcloud_websrv in ["nginx"]
+
+- name: "[SIGNED TLS] - Copy certificate chain file for apache2 to the host"
+  ansible.builtin.copy:
+    dest: "{{ nextcloud_tls_chain_file }}"
+    src: "{{ nextcloud_tls_src_chain }}"
+    owner: "{{ nextcloud_websrv_user }}"
+    group: "{{ nextcloud_websrv_group }}"
+    mode: u=rw,g=r,o=-
+    force: false
+  when:
+    - nextcloud_tls_src_chain is defined
+    - nextcloud_websrv not in ["nginx"]
 
 - name: "[SIGNED TLS] - Key is copied to the host"
   ansible.builtin.copy:
@@ -42,15 +54,5 @@
     src: "{{ nextcloud_tls_src_cert_key }}"
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
-    mode: "0400"
+    mode: u=r,g=-,o=-
     force: false
-
-- name: "[SIGNED TLS] - Certificate chain is copied to the host"
-  ansible.builtin.copy:
-    dest: "{{ nextcloud_tls_chain_file }}"
-    src: "{{ nextcloud_tls_src_chain }}"
-    owner: "{{ nextcloud_websrv_user }}"
-    group: "{{ nextcloud_websrv_group }}"
-    mode: "0640"
-    force: false
-  when: nextcloud_tls_src_chain is defined

--- a/roles/install_nextcloud/tasks/tls_signed.yml
+++ b/roles/install_nextcloud/tasks/tls_signed.yml
@@ -42,7 +42,7 @@
     src: "{{ nextcloud_tls_src_chain }}"
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
-    mode: u=rw,g=r,o=-
+    mode: 0400
     force: false
   when:
     - nextcloud_tls_src_chain is defined

--- a/roles/install_nextcloud/tasks/tls_signed.yml
+++ b/roles/install_nextcloud/tasks/tls_signed.yml
@@ -29,7 +29,7 @@
     dest: "{{ nextcloud_tls_cert_file }}"
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
-    mode: u=rw,g=r,o=-
+    mode: "0640"
   vars:
     input_files: ["{{ nextcloud_tls_src_cert }}", "{{ nextcloud_tls_src_chain }}"]
   when:

--- a/roles/install_nextcloud/tasks/tls_signed.yml
+++ b/roles/install_nextcloud/tasks/tls_signed.yml
@@ -18,7 +18,7 @@
     src: "{{ nextcloud_tls_src_cert }}"
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
-    mode: u=rw,g=r,o=-
+    mode: "0640"
     force: true
   when:
     - nextcloud_websrv not in ["nginx"]

--- a/roles/install_nextcloud/templates/apache2_nc.j2
+++ b/roles/install_nextcloud/templates/apache2_nc.j2
@@ -46,12 +46,13 @@
   DocumentRoot {{ nextcloud_webroot }}
   {% if (nextcloud_max_upload_size_in_bytes|int) <= 2147483647-%}
   LimitRequestBody {{ nextcloud_max_upload_size_in_bytes }}
+  LimitRequestFieldsize 32768
   {% endif -%}
   SSLEngine on
   SSLCertificateFile      {{ nextcloud_tls_cert_file }}
   SSLCertificateKeyFile   {{ nextcloud_tls_cert_key_file }}
-{% if nextcloud_tls_cert_chain_file is defined %}
-  SSLCertificateChainFile {{ nextcloud_tls_cert_chain_file }}
+{% if nextcloud_tls_chain_file is defined %}
+  SSLCertificateChainFile {{ nextcloud_tls_chain_file }}
 {% endif %}
 
   # enable HTTP/2, if available


### PR DESCRIPTION
…sible-lint warnings and add config-variable needed for SSO to nc_apache2.j2 template. The diff in tls_signed.yml looks a bit wired, as the change involved swapping two tasks only and adding some "when" conditionals. 