### PR TITLE
Dependency upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The collection includes a variety of Ansible content to help automate the manage
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.11.0**.
+This collection has been tested against following Ansible versions: **>=2.14.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 <!--end requires_ansible-->

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.11.0'
+requires_ansible: '>=2.14.0'

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,9 @@
 ---
 collections:
   - name: ansible.utils
-    version: 2.9.0
+    version: 3.0.0
   - name: community.general
-    version: 6.5.0
+    version: 8.2.0
 roles:
   - name: geerlingguy.php-versions
-    version: 5.0.1
+    version: 6.0.1

--- a/roles/backup/meta/main.yml
+++ b/roles/backup/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: BSD
 
-  min_ansible_version: "2.11"
+  min_ansible_version: "2.14"
 
   platforms:
     - name: EL

--- a/roles/install_nextcloud/meta/main.yml
+++ b/roles/install_nextcloud/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: BSD
 
-  min_ansible_version: "2.11"
+  min_ansible_version: "2.14"
 
   platforms:
     - name: Ubuntu


### PR DESCRIPTION
Note: ansible.utils 3.0.0 requires ansible 2.14, as it is a collection dependency we need the same.