### PR TITLE
Add missing become args

### DIFF
--- a/roles/install_nextcloud/tasks/nc_apps.yml
+++ b/roles/install_nextcloud/tasks/nc_apps.yml
@@ -28,6 +28,7 @@
 - name: "[App] - Download or copy Archive to apps folder from \"{{ nc_app_source }}\""
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
+  become: true
   ansible.builtin.unarchive:
     copy: "{{ nc_app_source is not url }}"
     src: "{{ nc_app_source }}"


### PR DESCRIPTION
Ansible lint shows somme error because that arg is missing for a specific task, so we simply add it (on a unarchive tasks with www server user)