### PR TITLE
Rename tasks to be closer to Ansible convention

### DIFF
--- a/roles/install_nextcloud/tasks/db_mysql.yml
+++ b/roles/install_nextcloud/tasks/db_mysql.yml
@@ -1,21 +1,21 @@
 ---
-- name: "[mySQL] - Service is installed."
+- name: db_mysql | Service is installed
   ansible.builtin.package:
     name: "{{ 'default-' if ((ansible_distribution | lower) == 'debian' and nextcloud_db_backend == 'mysql') else '' }}{{ nextcloud_db_backend }}-server"
     state: present
   register: nc_mysql_db_install
 
-- name: "[mySQL] - Check if MySQL packages were installed."
+- name: db_mysql | Check if MySQL packages were installed
   ansible.builtin.set_fact:
     mysql_install_packages: "{{ nc_mysql_db_install is defined and nc_mysql_db_install.changed }}"
 
-- name: "[mySQL] - Get MySQL version."
+- name: db_mysql | Get MySQL version
   ansible.builtin.command: 'mysql --version'
   register: mysql_cli_version
   changed_when: false
   check_mode: false
 
-- name: "[mySQL] - Packages are installed."
+- name: db_mysql | Install packages for MySQL
   ansible.builtin.package:
     name: "{{ nc_mysql_deps }}"
     state: present
@@ -23,14 +23,14 @@
     nc_mysql_deps:
       - "python3-pymysql"
 
-- name: "[mySQL] - Ensure MySQL is started and enabled on boot."
+- name: db_mysql | Ensure MySQL is started and enabled on boot
   ansible.builtin.service:
     name: "{{ mysql_daemon }}"
     state: started
     enabled: "{{ nextcloud_db_enabled_on_startup }}"
   register: mysql_service_configuration
 
-- name: "[mySQL] - Get list of hosts for the root user."
+- name: db_mysql | Get list of hosts for the root user
   ansible.builtin.command: mysql -NBe
     "SELECT Host
     FROM mysql.user
@@ -43,7 +43,7 @@
 
 # Note: We do not use mysql_user for this operation, as it doesn't always update
 # the root password correctly. See: https://goo.gl/MSOejW
-- name: "[mySQL] - Update MySQL root password for localhost root account (5.7.x)."
+- name: db_mysql | Update MySQL root password for localhost root account (5.7.x)
   ansible.builtin.shell: >
     mysql -u root -NBe
     'ALTER USER "root"@"{{ item }}"
@@ -55,7 +55,7 @@
   register: output
   changed_when: "output.rc == 0"
 
-- name: "[mySQL] - Update MySQL root password for localhost root account (< 5.7.x)."
+- name: db_mysql | Update MySQL root password for localhost root account (< 5.7.x)
   ansible.builtin.shell: >
     mysql -NBe
     'SET PASSWORD FOR "root"@"{{ item }}" = PASSWORD("{{ nextcloud_mysql_root_pwd }}"); FLUSH PRIVILEGES;'
@@ -66,7 +66,7 @@
   register: output
   changed_when: "output.rc == 0"
 
-- name: "[mySQL] - Copy .my.cnf file with root password credentials."
+- name: db_mysql | Copy .my.cnf file with root password credentials
   ansible.builtin.template:
     src: "root-my.cnf.j2"
     dest: "/root/.my.cnf"
@@ -75,32 +75,32 @@
     mode: 0600
   when: mysql_install_packages | bool or nextcloud_mysql_root_pwd_update
 
-- name: "[mySQL] - Get list of hosts for the anonymous user."
+- name: db_mysql | Get list of hosts for the anonymous user
   ansible.builtin.command: mysql -NBe 'SELECT Host FROM mysql.user WHERE User = ""'
   register: mysql_anonymous_hosts
   changed_when: false
   check_mode: false
 
-- name: "[mySQL] - Remove anonymous MySQL users."
+- name: db_mysql | Remove anonymous MySQL users
   community.mysql.mysql_user:
     name: ""
     host: "{{ item }}"
     state: absent
   with_items: "{{ mysql_anonymous_hosts.stdout_lines | default([]) }}"
 
-- name: "[mySQL] - Remove MySQL test database."
+- name: db_mysql | Remove MySQL test database
   community.mysql.mysql_db:
     name: 'test'
     state: absent
 
-- name: "[mySQL] - Set mysql config option for Nextcloud"
+- name: db_mysql | Set mysql config option for Nextcloud
   ansible.builtin.copy:
     dest: /etc/mysql/conf.d/nextcloud.cnf
     src: files/mysql_nextcloud.cnf
     mode: 0600
   notify: Restart mysql
 
-- name: "[mySQL] - Add Database {{ nextcloud_db_name }}"
+- name: db_mysql | Add Database {{ nextcloud_db_name }}"
   community.mysql.mysql_db:
     name: "{{ nextcloud_db_name }}"
     login_user: root
@@ -108,7 +108,7 @@
     config_file: "{{ mysql_credential_file[(ansible_os_family | lower)] | default(omit) }}"
     state: present
 
-- name: "[mySQL] - Configure the database user."
+- name: db_mysql | Configure the database user
   community.mysql.mysql_user:
     name: "{{ nextcloud_db_admin }}"
     password: "{{ nextcloud_db_pwd }}"

--- a/roles/install_nextcloud/tasks/db_postgresql.yml
+++ b/roles/install_nextcloud/tasks/db_postgresql.yml
@@ -1,5 +1,5 @@
 ---
-- name: "[PostgreSQL] - PostgreSQL packages are installed"
+- name: db_postgresql | Install PostgreSQL packages
   ansible.builtin.package:
     name: "{{ pg_deps }}"
     state: "present"
@@ -8,7 +8,7 @@
       - "postgresql"
       - "python3-psycopg2"
 
-- name: "[PostgreSQL] - nextcloud role is created."
+- name: db_postgresql | Create PostgreSQL Nextcloud role
   community.postgresql.postgresql_user:
     name: "{{ nextcloud_db_admin }}"
     password: "{{ nextcloud_db_pwd }}"
@@ -18,7 +18,7 @@
   become_user: postgres
   become: true
 
-- name: "[PostgreSQL] - nextcloud database is created."
+- name: db_postgresql | Create PostgreSQL Nextcloud database
   community.postgresql.postgresql_db:
     name: "{{ nextcloud_db_name }}"
     state: present

--- a/roles/install_nextcloud/tasks/http_apache.yml
+++ b/roles/install_nextcloud/tasks/http_apache.yml
@@ -1,5 +1,5 @@
 ---
-- name: "[APACHE] -  enable APC for php CLI"
+- name: http_apache | Enable APC for php CLI
   ansible.builtin.lineinfile:
     dest: "{{ php_dir }}/cli/php.ini"
     line: "apc.enable_cli = 1"
@@ -7,7 +7,7 @@
     state: present
     # validate: "/usr/sbin/{{ php_bin }} -t #%s"
 
-- name: "[APACHE] -  enable PHP OPcache for php.ini"
+- name: http_apache | Enable PHP OPcache for php.ini
   ansible.builtin.lineinfile:
     dest: "{{ php_dir }}/apache2/php.ini"
     state: present
@@ -26,7 +26,7 @@
     # validate: "/usr/sbin/{{ php_bin }} -t #%s"
   notify: Reload http
 
-- name: "[APACHE] -  Required Apache2 modules are enabled"
+- name: http_apache | Enable required Apache2 modules
   community.general.apache2_module:
     name: "{{ item }}"
     state: present
@@ -38,7 +38,7 @@
     - mime
   notify: Restart http
 
-- name: "[APACHE] -  Ssl Apache2 module is enabled"
+- name: http_apache | Enable ssl Apache2 module
   community.general.apache2_module:
     state: present
     name: "{{ item }}"
@@ -47,21 +47,21 @@
   when: (nextcloud_install_tls | bool)
   notify: Restart http
 
-- name: "[APACHE] -  generate Nextcloud configuration for apache"
+- name: http_apache | Generate Nextcloud configuration for apache
   ansible.builtin.template:
     dest: /etc/apache2/sites-available/nc_{{ nextcloud_instance_name }}.conf
     src: "{{ nextcloud_websrv_template }}"
     mode: 0640
   notify: Reload http
 
-- name: "[APACHE] -  Enable Nextcloud site in apache conf"
+- name: http_apache | Enable Nextcloud site in apache conf
   ansible.builtin.file:
     path: /etc/apache2/sites-enabled/nc_{{ nextcloud_instance_name }}.conf
     src: /etc/apache2/sites-available/nc_{{ nextcloud_instance_name }}.conf
     state: link
   notify: Reload http
 
-- name: "[APACHE] -  Disable apache default site"
+- name: http_apache | Disable apache default site
   ansible.builtin.file:
     path: /etc/apache2/sites-enabled/000-default.conf
     state: absent

--- a/roles/install_nextcloud/tasks/http_nginx.yml
+++ b/roles/install_nextcloud/tasks/http_nginx.yml
@@ -1,5 +1,5 @@
 ---
-- name: "[NGINX] -  remove some commented line in php-fpm conf"
+- name: http_nginx | Remove some commented line in php-fpm conf
   ansible.builtin.lineinfile:
     dest: "{{ php_dir }}/fpm/pool.d/www.conf"
     regexp: '^\;env'
@@ -7,7 +7,7 @@
     # validate: "/usr/sbin/{{ php_bin }} -t #%s"
   notify: Reload php-fpm
 
-- name: "[NGINX] -  Add path variable to php-fpm"
+- name: http_nginx | Add path variable to php-fpm
   ansible.builtin.blockinfile:
     dest: "{{ php_dir }}/fpm/pool.d/www.conf"
     insertafter: '^; Default Value: clean env$'
@@ -20,7 +20,7 @@
       env[TEMP] = /tmp
   notify: Reload php-fpm
 
-- name: "[NGINX] -  enable APC for php CLI"
+- name: http_nginx | Enable APC for php CLI
   ansible.builtin.lineinfile:
     dest: "{{ php_dir }}/cli/php.ini"
     line: "apc.enable_cli = 1"
@@ -29,7 +29,7 @@
     # validate: "/usr/sbin/{{ php_bin }} -t #%s"
   notify: Reload php-fpm
 
-- name: "[NGINX] -  enable PHP OPcache for php.ini"
+- name: http_nginx | Enable PHP OPcache for php.ini
   ansible.builtin.lineinfile:
     dest: "{{ php_dir }}/fpm/php.ini"
     state: present
@@ -49,40 +49,40 @@
   notify: Reload php-fpm
 
 
-- name: "[NGINX] -  Public Diffie-Hellman Parameter are generated. This might take a while."
+- name: http_nginx | Generate Public Diffie-Hellman parameter (This might take a while)
   ansible.builtin.command: "openssl dhparam -out {{ nextcloud_tls_dhparam }} 2048"
   args:
     creates: "{{ nextcloud_tls_dhparam }}"
 
-- name: "[NGINX] -  php handler configuration is present."
+- name: http_nginx | Configure php handler
   ansible.builtin.template:
     dest: /etc/nginx/sites-available/php_handler.cnf
     src: templates/nginx_php_handler.j2
     mode: 0640
   notify: Reload http
 
-- name: "[NGINX] -  php handler is enabled"
+- name: http_nginx | Enable php handler
   ansible.builtin.file:
     path: /etc/nginx/sites-enabled/php_handler
     src: /etc/nginx/sites-available/php_handler.cnf
     state: link
   notify: Reload http
 
-- name: "[NGINX] -  generate Nextcloud configuration for nginx"
+- name: http_nginx | Generate Nextcloud configuration for nginx
   ansible.builtin.template:
     dest: /etc/nginx/sites-available/nc_{{ nextcloud_instance_name }}.cnf
     src: "{{ nextcloud_websrv_template }}"
     mode: 0640
   notify: Reload http
 
-- name: "[NGINX] -  Enable Nextcloud in nginx conf"
+- name: http_nginx | Enable Nextcloud in nginx conf
   ansible.builtin.file:
     path: /etc/nginx/sites-enabled/nc_{{ nextcloud_instance_name }}
     src: /etc/nginx/sites-available/nc_{{ nextcloud_instance_name }}.cnf
     state: link
   notify: Reload http
 
-- name: "[NGINX] -  Disable nginx default site"
+- name: http_nginx | Disable nginx default site
   ansible.builtin.file:
     path: /etc/nginx/sites-enabled/default
     state: absent

--- a/roles/install_nextcloud/tasks/main.yml
+++ b/roles/install_nextcloud/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 # tasks file for nextcloud
 
-- name: "Load os specific variables"
+- name: Load os specific variables
   ansible.builtin.include_tasks: ./setup_env.yml
   tags:
     - install_apps
 
-- name: "Install PHP packages"
+- name: Install PHP packages
   ansible.builtin.include_tasks: php_install.yml
   tags:
     - install_apps
@@ -91,7 +91,7 @@
     - install_apps
     - patch_user_saml_app
   block:
-    - name: "[NC apps] - lists the number of apps available in the instance."
+    - name: Lists the number of apps available in the instance
       ansible.builtin.command: php occ app:list --output=json_pretty --no-warnings
       args:
         chdir: "{{ nextcloud_webroot }}"
@@ -102,11 +102,11 @@
       check_mode: false
       register: nc_apps_list
 
-    - name: "[NC apps] - convert list to yaml."
+    - name: Convert list to yaml
       ansible.builtin.set_fact:
         nc_available_apps: "{{ nc_apps_list.stdout | from_json }}"
 
-    - name: "[NC apps] - installation."
+    - name: Install apps
       ansible.builtin.include_tasks: ./nc_apps.yml
       # do if the app is not enabled and ( (archive path is not "") or (app is disabled) )
       when:
@@ -126,7 +126,7 @@
   changed_when: '"Done" not in nc_indices_cmd.stdout'
   when: nextcloud_install_db
 
-- name: "[Main] - Patch from the app 'user_saml' the file SAMLController.php."
+- name: Main | Patch from the app 'user_saml' the file SAMLController.php
   when:
     - nextcloud_patch_user_saml_app
     - nc_available_apps.enabled['user_saml'] is defined or nc_available_apps.disabled['user_saml'] is defined
@@ -136,12 +136,12 @@
     pattern: '.*\$this->session->set\(.user_saml\.samlUserData.,\s+\$_SERVER\);.*'
     file2patch: "{{ nextcloud_webroot + '/apps/user_saml/lib/Controller/SAMLController.php' }}"
   block:
-    - name: "[Main] - Check if SAMLController.php can be patched."
+    - name: Main | Check if SAMLController.php can be patched
       ansible.builtin.slurp:
         src: "{{ file2patch }}"
       register: df_file
 
-    - name: "[Main] - Patch file SAMController.php."
+    - name: Main | Patch file SAMController.php
       ansible.builtin.blockinfile:
         block: "{{ lookup('ansible.builtin.file', 'files/SAMLController.patch') }}"
         path: "{{ file2patch }}"

--- a/roles/install_nextcloud/tasks/nc_apps.yml
+++ b/roles/install_nextcloud/tasks/nc_apps.yml
@@ -1,18 +1,18 @@
 ---
-- name: "[App] - Parse the item values"
+- name: nc_apps | Parse the item values
   ansible.builtin.set_fact:
     nc_app_name: "{{ item.key }}"
     nc_app_source: "{{ item.value.source if item.value.source is defined else item.value }}"
     nc_app_cfg: "{{ item.value }}"
 
-- name: "[App] - Verify the yaml declaration for the app \"{{ nc_app_name }}\""
+- name: "nc_apps | Verify the yaml declaration for the app \"{{ nc_app_name }}\""
   ansible.builtin.assert:
     that:
       - (nc_app_cfg.source is defined) and (nc_app_cfg.source is string)
     msg: "{{ nc_app_name }} is not well declared."
   when: nc_app_cfg is not string
 
-- name: "[App] - Install from the official app-store app: \"{{ nc_app_name }}\""
+- name: "nc_apps | Install from the official app-store app: \"{{ nc_app_name }}\""
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true
@@ -25,7 +25,7 @@
   register: output
   changed_when: "output.rc == 0"
 
-- name: "[App] - Download or copy Archive to apps folder from \"{{ nc_app_source }}\""
+- name: "nc_apps | Download or copy Archive to apps folder from \"{{ nc_app_source }}\""
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   ansible.builtin.unarchive:
@@ -39,7 +39,7 @@
     - (nc_app_source is string) and (nc_app_source | length > 0)
     - nc_app_name not in nc_available_apps.disabled
 
-- name: "[App] - Enable the application \"{{ nc_app_name }}\""
+- name: "nc_apps | Enable the application \"{{ nc_app_name }}\""
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true
@@ -48,7 +48,7 @@
     chdir: "{{ nextcloud_webroot }}"
   changed_when: true
 
-- name: "[App] - Configure the application \"{{ nc_app_name }}\""
+- name: "nc_apps | Configure the application \"{{ nc_app_name }}\""
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true

--- a/roles/install_nextcloud/tasks/nc_download.yml
+++ b/roles/install_nextcloud/tasks/nc_download.yml
@@ -1,22 +1,22 @@
 ---
-- name: "[NC-DL] - Unzip is installed"
+- name: nc_download | Install unzip package
   ansible.builtin.package:
     name: unzip
     state: present
   when: nextcloud_archive_format == "zip"
 
-- name: "[NC-DL] - bunzip2 is installed"
+- name: nc_download | Install bunzip2 package
   ansible.builtin.package:
     name: bzip2
     state: present
   when: nextcloud_archive_format == "tar.bz2"
 
-- name: "[NC-DL] - You must specify the major version"
+- name: nc_download | You must specify the major version
   ansible.builtin.assert:
     that: nextcloud_version_major is defined
   when: nextcloud_full_src is defined
 
-- name: "[NC-DL] - Create and set directory ownership & permissions for the webroot folder"
+- name: nc_download | Create and set directory ownership & permissions for the webroot folder
   ansible.builtin.file:
     path: "{{ nextcloud_webroot }}"
     mode: "u=rwX,g=rX,o-rwx"
@@ -25,9 +25,9 @@
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
 
-- name: "Download and extract Nextcloud"
+- name: nc_download | Download and extract Nextcloud
   block:
-    - name: "[NC-DL] - Download & extract Nextcloud to /tmp."
+    - name: nc_download | Download & extract Nextcloud to /tmp."
       ansible.builtin.unarchive:
         copy: "{{ (nextcloud_full_src is not url) if (nextcloud_full_src is defined) else false }}"
         src: "{{ nextcloud_full_src | default(nextcloud_calculated_url) }}"
@@ -37,13 +37,13 @@
         nextcloud_calculated_file: "{{ [nextcloud_dl_file_name[just_a_dict_key], nextcloud_archive_format] | join('.') }}"
         just_a_dict_key: "{{ 'latest' if ((nextcloud_get_latest | bool) and (nextcloud_version_channel != 'prereleases')) else nextcloud_version_channel }}"
 
-    - name: "[NC-DL] - Move extracted files to {{ nextcloud_webroot }}"
+    - name: "nc_download | Move extracted files to {{ nextcloud_webroot }}"
       ansible.builtin.command: "cp -r /tmp/nextcloud/. {{ nextcloud_webroot }}/"
       when: nextcloud_webroot is not none
       register: output
       changed_when: "output.rc == 0"
 
-    - name: "[NC-DL] - Remove nextcloud archive files"
+    - name: nc_download | Remove nextcloud archive files
       ansible.builtin.file:
         path: /tmp/nextcloud
         state: absent

--- a/roles/install_nextcloud/tasks/nc_installation.yml
+++ b/roles/install_nextcloud/tasks/nc_installation.yml
@@ -2,10 +2,10 @@
 #########
 # Run command line installation.
 # the web server must be running by now in order to launch the installation
-- name: Trigger all pending handlers
+- name: nc_installation | Trigger all pending handlers
   ansible.builtin.meta: flush_handlers
 
-- name: "[NC] - Setting directory ownership & permissions for the data folder"
+- name: nc_installation | Set directory ownership & permissions for the data folder
   ansible.builtin.file:
     path: "{{ nextcloud_data_dir }}"
     mode: "u=rwX,g=rX,o-rwx"
@@ -14,12 +14,12 @@
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
 
-- name: "[NC] - Generate password {{ nextcloud_admin_name }}"
+- name: "nc_installation | Generate password {{ nextcloud_admin_name }}"
   ansible.builtin.set_fact:
     nextcloud_admin_pwd: "{{ lookup('password', 'nextcloud_instances/' + nextcloud_instance_name + '/web_admin.pwd') }}"
   when: nextcloud_admin_pwd is not defined
 
-- name: "[NC] - Set temporary permissions for command line installation."
+- name: nc_installation | Set temporary permissions for command line installation
   ansible.builtin.file:
     path: "{{ nextcloud_webroot }}"
     state: directory
@@ -27,14 +27,14 @@
     owner: "{{ nextcloud_websrv_user }}"
     group: "{{ nextcloud_websrv_group }}"
 
-- name: "[NC] - Configuration"
+- name: nc_installation | Configuration
   block:
-    - name: "[NC] - removing possibly old or incomplete config.php"
+    - name: nc_installation | Remove possibly old or incomplete config.php
       ansible.builtin.file:
         path: "{{ nextcloud_webroot }}/config/config.php"
         state: absent
 
-    - name: "[NC] - Run occ installation command"
+    - name: nc_installation | Run occ installation command
       become_user: "{{ nextcloud_websrv_user }}"
       become_flags: "{{ ansible_become_flags | default(omit) }}"
       become: true
@@ -56,13 +56,13 @@
         nextcloud_tmp_backend: "{{ 'mysql' if nextcloud_db_backend == 'mariadb' else nextcloud_db_backend }}"
       notify: Reload http
 
-    - name: "[NC] - Verify config.php - check filesize"
+    - name: nc_installation | Verify config.php - check filesize
       ansible.builtin.stat:
         path: "{{ nextcloud_webroot }}/config/config.php"
       register: nc_installation_confsize
       failed_when: nc_installation_confsize.stat.size is undefined or nc_installation_confsize.stat.size <= 100
 
-    - name: "[NC] - Verify config.php - php syntax check"
+    - name: nc_installation | Verify config.php - php syntax check
       ansible.builtin.command: "php -l {{ nextcloud_webroot }}/config/config.php"
       register: nc_installation_confphp
       changed_when: false
@@ -74,13 +74,13 @@
     # - name: Unfix su issue with occ
     #   include_tasks: tasks/unfix_su.yml
     #   when: ansible_become_method == "su"
-    - name: "[NC] - removing config.php when occ fail"
+    - name: nc_installation | Remove config.php when occ fail
       ansible.builtin.file:
         path: "{{ nextcloud_webroot }}/config/config.php"
         state: absent
       failed_when: true
 
-- name: "[NC] - Set Trusted Domains"
+- name: nc_installation | Set Trusted Domains
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true
@@ -90,7 +90,7 @@
   with_indexed_items: "{{ nextcloud_trusted_domain }}"
   changed_when: true
 
-- name: "[NC] - Set Trusted Proxies"
+- name: nc_installation | Set Trusted Proxies
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true
@@ -100,7 +100,7 @@
   with_indexed_items: "{{ nextcloud_trusted_proxies }}"
   changed_when: true
 
-- name: "[NC] - Set Nextcloud settings in config.php"
+- name: nc_installation | Set Nextcloud settings in config.php
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true
@@ -111,7 +111,7 @@
     - "{{ nextcloud_config_settings }}"
   changed_when: true
 
-- name: "[NC] - Set Redis Server"
+- name: nc_installation | Set Redis Server
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true
@@ -124,15 +124,15 @@
   register: output
   changed_when: "output.rc == 0"
 
-- name: "[NC] - Configure Cron"
+- name: nc_installation | Configure Cron
   when: (nextcloud_background_cron | bool)
   block:
-    - name: "[NC] - Check Cron package"
+    - name: nc_installation | Check Cron package
       ansible.builtin.package:
         name: "cron"
         state: present
 
-    - name: "[NC] - Install Cronjob"
+    - name: nc_installation | Install Cronjob
       ansible.builtin.cron:
         name: "Nextcloud Cronjob"
         minute: "*/10"
@@ -140,7 +140,7 @@
         job: "php {{ nextcloud_webroot }}/cron.php"
         cron_file: "nextcloud"
 
-- name: "[NC] - Set Cron method to Crontab"
+- name: nc_installation | Set Cron method to Crontab
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"
   become: true
@@ -151,23 +151,23 @@
   register: output
   changed_when: "output.rc == 0"
 
-- name: "[NC] - Set Custom Mimetype"
+- name: nc_installation | Set Custom Mimetype
   ansible.builtin.copy:
     dest: "{{ nextcloud_webroot }}/config/mimetypemapping.json"
     src: files/nextcloud_custom_mimetypemapping.json
     mode: 0640
 
-- name: "[NC] - Ensure Nextcloud directories are 0750"
+- name: nc_installation | Ensure Nextcloud directories are 0750
   ansible.builtin.command: find {{ nextcloud_data_dir }} -type d -exec chmod -c 0750 {} \;
   register: nc_installation_chmod_result
   changed_when: "nc_installation_chmod_result.stdout != \"\""
 
-- name: "[NC] - Ensure Nextcloud files are 0640"
+- name: nc_installation | Ensure Nextcloud files are 0640
   ansible.builtin.command: find {{ nextcloud_data_dir }} -type f -exec chmod -c 0640 {} \;
   register: nc_installation_chmod_result
   changed_when: "nc_installation_chmod_result.stdout != \"\""
 
-- name: "[NC] - Setting stronger directory ownership"
+- name: nc_installation | Set stronger directory ownership
   ansible.builtin.file:
     path: "{{ nextcloud_webroot }}/{{ item }}/"
     recurse: true
@@ -180,7 +180,7 @@
     - themes
     - updater
 
-- name: "[NC apps] - Disable Nextcloud apps"
+- name: nc_installation | Disable Nextcloud apps
   ansible.builtin.command: php occ app:disable "{{ item }}"
   become_user: "{{ nextcloud_websrv_user }}"
   become_flags: "{{ ansible_become_flags | default(omit) }}"

--- a/roles/install_nextcloud/tasks/php_install.yml
+++ b/roles/install_nextcloud/tasks/php_install.yml
@@ -1,12 +1,12 @@
 ---
-- name: "[PHP] - External repository is installed."
+- name: php_install | Add external repository for PHP by using geerlingguy role
   ansible.builtin.import_role:
     name: geerlingguy.php-versions
   vars:
     php_version: "{{ php_ver }}"
   when: php_install_external_repos
 
-- name: "[PHP] - Required and recommended packages are installed."
+- name: php_install | Install required PHP packages for Nextcloud
   ansible.builtin.package:
     name:
       - imagemagick
@@ -22,24 +22,24 @@
   notify:
     - Start php-fpm
 
-- name: "[PHP] - Extra packages are installed."
+- name: php_install | Install extra packages
   ansible.builtin.package:
     name: "{{ php_pkg_spe }}"
     state: present
 
-- name: "[PHP] - Database client - MySQL."
+- name: php_install | Install php*-mysql package
   ansible.builtin.package:
     name: "php{{ php_ver }}-mysql"
     state: present
   when: (nextcloud_db_backend == "mysql") or (nextcloud_db_backend == "mariadb")
 
-- name: "[PHP] - Database client - PostgreSQL."
+- name: php_install | Install php*-pgsql package
   ansible.builtin.package:
     name: "php{{ php_ver }}-pgsql"
     state: present
   when: (nextcloud_db_backend == "pgsql")
 
-- name: "[PHP] - APCu is installed."
+- name: php_install | Install PHP APCu pacakge
   ansible.builtin.package:
     name: "php{{ php_ver }}-apcu"
     state: present

--- a/roles/install_nextcloud/tasks/redis_server.yml
+++ b/roles/install_nextcloud/tasks/redis_server.yml
@@ -1,5 +1,5 @@
 ---
-- name: "[REDIS] -  Required packages are installed."
+- name: redis_server | Install redis server packages
   ansible.builtin.package:
     name: "{{ redis_deps }}"
     state: present
@@ -9,7 +9,7 @@
       - "php{{ php_ver }}-redis"
   notify: Start redis
 
-- name: "[REDIS] -  Redis configuration is present."
+- name: redis_server | Configure redis server
   ansible.builtin.template:
     dest: /etc/redis/redis.conf
     src: templates/redis.conf.j2

--- a/roles/install_nextcloud/tasks/setup_env.yml
+++ b/roles/install_nextcloud/tasks/setup_env.yml
@@ -1,11 +1,11 @@
 ---
 # additional setup and fixes for OS dependent environment
-- name: "[ENV] controls nextcloud_trusted_domain type"
+- name: setup_env | Controls nextcloud_trusted_domain type
   ansible.builtin.fail:
     msg: "New versions require nextcloud_trusted_domain to be declared as a list."
   when: nextcloud_trusted_domain is string
 
-- name: "[ENV] - ca-certificate are up to date"
+- name: setup_env | Update ca-certificate
   # needed for downloading from download.nextcloud.com as the site use letsencrypt certificates
   # letsencrypt may not be trusted on older OS
   ansible.builtin.apt:
@@ -18,7 +18,7 @@
     - ca-certificates
   when: ansible_os_family in [ "Debian" ]
 
-- name: "[ENV] - Upgrade all packages to latest version."
+- name: setup_env | Upgrade all packages to latest version
   ansible.builtin.apt:
     upgrade: "yes"
     force_apt_get: true
@@ -28,31 +28,31 @@
 
   # fix for debian not using sudo :
   # finding out if sudo is installed or not
-- name: "[ENV] - Debian only : checking sudo."
+- name: setup_env | Check if sudo is installed (only on Debian)
   ansible.builtin.command: "dpkg -l sudo"
   changed_when: false
   register: nc_sudo_installed_result
   failed_when: false
   when: ansible_distribution == "Debian"
 
-- name: "[ENV] - Checking su"
+- name: setup_env | Deterime become_method or becom_flags
   when:
     - nc_sudo_installed_result.rc is defined
     - nc_sudo_installed_result.rc != 0
   block:
-    - name: "[ENV] - rolling back to su."
+    - name: setup_env | Rolling back to su
       ansible.builtin.set_fact:
         ansible_become_method: "su"
-    - name: "[ENV] - force su to use /bin/sh as shell"
+    - name: setup_env | Force su to use /bin/sh as shell
       ansible.builtin.set_fact:
         ansible_become_flags: '-s /bin/sh'
 
-- name: "[ENV] - Generate database user password."
+- name: setup_env | Generate database user password
   ansible.builtin.set_fact:
     nextcloud_db_pwd: "{{ lookup('ansible.builtin.password', 'nextcloud_instances/' + nextcloud_instance_name + '/db_admin.pwd') }}"
   when: nextcloud_db_pwd is not defined
 
-- name: "[ENV] - Generate database root password."
+- name: setup_env | Generate database root password
   ansible.builtin.set_fact:
     nextcloud_mysql_root_pwd: "{{ lookup('ansible.builtin.password', 'nextcloud_instances/' + nextcloud_instance_name + '/db_root.pwd') }}"
   when:

--- a/roles/install_nextcloud/tasks/tls_installed.yml
+++ b/roles/install_nextcloud/tasks/tls_installed.yml
@@ -1,13 +1,13 @@
 ---
-- name: "[INSTALLED TLS] - Define certificate path"
+- name: tls_installed | Define certificate path
   ansible.builtin.set_fact:
     nextcloud_tls_cert_file: "{{ nextcloud_tls_cert }}"
 
-- name: "[INSTALLED TLS] - Define key path"
+- name: tls_installed | Define key path
   ansible.builtin.set_fact:
     nextcloud_tls_cert_key_file: "{{ nextcloud_tls_cert_key }}"
 
-- name: "[INSTALLED TLS] - Define certificate chain path"
+- name: tls_installed | Define certificate chain path
   ansible.builtin.set_fact:
     nextcloud_tls_chain_file: "{{ nextcloud_tls_cert_chain }}"
   when: nextcloud_tls_cert_chain is defined

--- a/roles/install_nextcloud/tasks/tls_selfsigned.yml
+++ b/roles/install_nextcloud/tasks/tls_selfsigned.yml
@@ -1,13 +1,13 @@
 ---
-- name: "[Selfsigned TLS] - Define private certificate path"
+- name: tls_selfsigned | Define private certificate path
   ansible.builtin.set_fact:
     nextcloud_tls_cert_file: "/etc/ssl/{{ nextcloud_instance_name }}.crt"
 
-- name: "[Selfsigned TLS] - Define private key path"
+- name: tls_selfsigned | Define private key path
   ansible.builtin.set_fact:
     nextcloud_tls_cert_key_file: "/etc/ssl/{{ nextcloud_instance_name }}.key"
 
-- name: "[Selfsigned TLS] - Create self-signed SSL cert"
+- name: tls_selfsigned | Create self-signed SSL cert
   ansible.builtin.command: >
     openssl req -new -nodes -x509
     -subj "/C=US/ST=Oregon/L=Portland/O=IT/CN=${hostname --fqdn}"
@@ -18,13 +18,13 @@
   args:
     creates: "{{ nextcloud_tls_cert_key_file }}"
 
-- name: "[Selfsigned TLS] - check TLS certificate permissions"
+- name: tls_selfsigned | Check TLS certificate permissions
   ansible.builtin.file:
     path: "{{ nextcloud_tls_cert_file }}"
     mode: 0644
     group: "{{ nextcloud_websrv_group }}"
 
-- name: "[Selfsigned TLS] - check TLS key permissions"
+- name: tls_selfsigned | Check TLS key permissions
   ansible.builtin.file:
     path: "{{ nextcloud_tls_cert_key_file }}"
     mode: 0640

--- a/roles/install_nextcloud/tasks/tls_signed.yml
+++ b/roles/install_nextcloud/tasks/tls_signed.yml
@@ -1,18 +1,18 @@
 ---
-- name: "[SIGNED TLS] - Define signed certificate-file with abolute path"
+- name: tls_signed | Define signed certificate-file with abolute path
   ansible.builtin.set_fact:
     nextcloud_tls_cert_file: "{{ nextcloud_tls_cert_file | default(cert_path + nextcloud_instance_name + \".crt\") }}"
 
-- name: "[SIGNED TLS] - Define signed certificate's key-file with absolute path"
+- name: tls_signed | Define signed certificate's key-file with absolute path
   ansible.builtin.set_fact:
     nextcloud_tls_cert_key_file: "{{ nextcloud_tls_cert_key_file | default(cert_path + nextcloud_instance_name + \".key\") }}"
 
-- name: "[SIGNED TLS] - Define certificate chain-file with absolute path"
+- name: tls_signed | Define certificate chain-file with absolute path
   ansible.builtin.set_fact:
     nextcloud_tls_chain_file: "{{ nextcloud_tls_chain_file | default(cert_path + nextcloud_instance_name + \".pem\") }}"
   when: nextcloud_tls_src_chain is defined
 
-- name: "[SIGNED TLS] - Copy certificate file for apache2 to the host"
+- name: tls_signed | Copy certificate file for apache2 to the host
   ansible.builtin.copy:
     dest: "{{ nextcloud_tls_cert_file }}"
     src: "{{ nextcloud_tls_src_cert }}"
@@ -23,7 +23,7 @@
   when:
     - nextcloud_websrv not in ["nginx"]
 
-- name: "[SIGNED TLS] - Copy and concatenate chained certificate file for nginx to host"
+- name: tls_signed | Copy and concatenate chained certificate file for nginx to host
   ansible.builtin.template:
     src: templates/concatenate.j2
     dest: "{{ nextcloud_tls_cert_file }}"
@@ -36,7 +36,7 @@
     - nextcloud_tls_src_chain is defined
     - nextcloud_websrv in ["nginx"]
 
-- name: "[SIGNED TLS] - Copy certificate chain file for apache2 to the host"
+- name: tls_signed | Copy certificate chain file for apache2 to the host
   ansible.builtin.copy:
     dest: "{{ nextcloud_tls_chain_file }}"
     src: "{{ nextcloud_tls_src_chain }}"
@@ -48,7 +48,7 @@
     - nextcloud_tls_src_chain is defined
     - nextcloud_websrv not in ["nginx"]
 
-- name: "[SIGNED TLS] - Key is copied to the host"
+- name: tls_signed | Copy key to the host
   ansible.builtin.copy:
     dest: "{{ nextcloud_tls_cert_key_file }}"
     src: "{{ nextcloud_tls_src_cert_key }}"

--- a/roles/install_nextcloud/tasks/websrv_install.yml
+++ b/roles/install_nextcloud/tasks/websrv_install.yml
@@ -1,12 +1,12 @@
 ---
-- name: "[INSTALL] - Web server is installed."
+- name: websrv_install | Install web server packages
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
   with_items:
     - "{{ nextcloud_websrv }}"
 
-- name: "[INSTALL] - Apache required package is installed."
+- name: websrv_install | Install specific Apache web server packages
   ansible.builtin.package:
     name: "libapache2-mod-php{{ php_ver }}"
     state: present
@@ -15,7 +15,7 @@
     - Start http
     - Reload php-fpm
 
-- name: "[INSTALL] - NGINX required package is installed."
+- name: websrv_install | Install specific NGINX web server packages
   ansible.builtin.package:
     name: "php{{ php_ver }}-fpm"
     state: present


### PR DESCRIPTION
We try to fix some (small) issues with tasks names and adapt them to respect (as much as possible) the recommended convention from ansible-lint and Ansible:

https://ansible.readthedocs.io/projects/lint/rules/name/

Basicly we:

- Remove the useless "
- Ensure all tasks names start with a Capital letter
- Add a prefix for tasks within sub-tasks files
- Avoid templating in tasks names
- Try to use / favorise present-tense and imperative style