### PR TITLE
Fix CI  / Disable idempotency check on add indice

### DIFF
--- a/roles/install_nextcloud/tasks/main.yml
+++ b/roles/install_nextcloud/tasks/main.yml
@@ -125,6 +125,8 @@
   register: nc_indices_cmd
   changed_when: '"Done" not in nc_indices_cmd.stdout'
   when: nextcloud_install_db
+  tags:
+    - molecule-idempotence-notest
 
 - name: Main | Patch from the app 'user_saml' the file SAMLController.php
   when:


### PR DESCRIPTION
We disable idempotency check on Add indice task to fix the CI, one better option is propably to adapt occ wrapper to have some custom task for that.