### PR TITLE
Add func to module_utils/occ.py to convert string to list with two or much words in parameters

### DIFF
--- a/plugins/module_utils/occ.py
+++ b/plugins/module_utils/occ.py
@@ -24,7 +24,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+from shlex import shlex
 
+def convert_string(command: str) -> list:
+    command_list = shlex(command, posix=True)
+    command_list.whitespace_split = True
+    if command_list.find("'") > 0:
+        command_list.quotes = "'"
+    elif command_list.find('"') > 0:
+        command_list.quotes = '"'
+    return list(command_list)
 
 def run_occ(
     module,
@@ -41,7 +50,7 @@ def run_occ(
     if isinstance(command, list):
         full_command = [cli_full_path] + command
     elif isinstance(command, str):
-        full_command = [cli_full_path] + command.split(" ")
+        full_command = [cli_full_path] + convert_string(command)
 
     returnCode, stdOut, stdErr = module.run_command([php_exec] + full_command)
 

--- a/plugins/module_utils/occ.py
+++ b/plugins/module_utils/occ.py
@@ -27,13 +27,13 @@ import os
 from shlex import shlex
 
 def convert_string(command: str) -> list:
-    command_list = shlex(command, posix=True)
-    command_list.whitespace_split = True
-    if command_list.find("'") > 0:
-        command_list.quotes = "'"
-    elif command_list.find('"') > 0:
-        command_list.quotes = '"'
-    return list(command_list)
+    command_lex = shlex(command, posix=True)
+    command_lex.whitespace_split = True
+    if command.find("'") > 0:
+        command_lex.quotes = "'"
+    elif command.find('"') > 0:
+        command_lex.quotes = '"'
+    return list(command_lex)
 
 def run_occ(
     module,


### PR DESCRIPTION
fix problem when run occ command with two or much words in parameter, for example:
```
nextcloud.admin.run_occ:
  command: group:add -- "Some group name"
  nextcloud_path: "/var/www/nextcloud"

```
or
```
nextcloud.admin.run_occ:
  command: group:add -- 'Some another group name'
  nextcloud_path: "/var/www/nextcloud"

```
parameter "Some group name" reading like each different option - ['"Some', 'group', 'name"'] and not like ['"Some group name"']
P.S.: sorry, in previous commit got logic and name mistakes