### PR TITLE
adds libmagickcore-extra package

### DIFF
--- a/roles/install_nextcloud/tasks/php_install.yml
+++ b/roles/install_nextcloud/tasks/php_install.yml
@@ -10,6 +10,7 @@
   ansible.builtin.package:
     name:
       - imagemagick
+      - libmagickcore-*-extra
       - smbclient
       - "php{{ php_ver }}-fpm"
       - "php{{ php_ver }}-gd"


### PR DESCRIPTION
Fixes #386 

Adds the libmagickcore-*-extra package to install dependencies for SVG support.