### PR TITLE
Adds support for occ commands with parameters

### DIFF
--- a/plugins/module_utils/occ.py
+++ b/plugins/module_utils/occ.py
@@ -24,16 +24,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-from shlex import shlex
+import shlex
 
-def convert_string(command: str) -> list:
-    command_lex = shlex(command, posix=True)
-    command_lex.whitespace_split = True
-    if command.find("'") > 0:
-        command_lex.quotes = "'"
-    elif command.find('"') > 0:
-        command_lex.quotes = '"'
-    return list(command_lex)
 
 def run_occ(
     module,
@@ -50,18 +42,10 @@ def run_occ(
     if isinstance(command, list):
         full_command = [cli_full_path] + command
     elif isinstance(command, str):
-        full_command = [cli_full_path] + convert_string(command)
+        # Use shlex.split to handle quoted strings properly
+        full_command = [cli_full_path] + shlex.split(command)
 
     returnCode, stdOut, stdErr = module.run_command([php_exec] + full_command)
-
-    if "is in maintenance mode" in stdErr:
-        module.warn(" ".join(stdErr.splitlines()[0:1]))
-        maintenanceMode = True
-    else:
-        maintenanceMode = False
-
-    if "is not installed" in stdErr:
-        module.warn(stdErr.splitlines()[0])
 
     if returnCode != 0:
         module.fail_json(
@@ -72,4 +56,4 @@ def run_occ(
             stderr=stdErr,
             command=command,
         )
-    return returnCode, stdOut, stdErr, maintenanceMode
+    return returnCode, stdOut, stdErr

--- a/plugins/module_utils/occ.py
+++ b/plugins/module_utils/occ.py
@@ -47,6 +47,15 @@ def run_occ(
 
     returnCode, stdOut, stdErr = module.run_command([php_exec] + full_command)
 
+    if "is in maintenance mode" in stdErr:
+        module.warn(" ".join(stdErr.splitlines()[0:1]))
+        maintenanceMode = True
+    else:
+        maintenanceMode = False
+
+    if "is not installed" in stdErr:
+        module.warn(stdErr.splitlines()[0])
+
     if returnCode != 0:
         module.fail_json(
             msg="Failure when executing occ command. Exited {0}.\nstdout: {1}\nstderr: {2}".format(
@@ -56,4 +65,4 @@ def run_occ(
             stderr=stdErr,
             command=command,
         )
-    return returnCode, stdOut, stdErr
+    return returnCode, stdOut, stdErr, maintenanceMode

--- a/plugins/module_utils/occ.py
+++ b/plugins/module_utils/occ.py
@@ -49,9 +49,6 @@ def run_occ(
 
     if "is in maintenance mode" in stdErr:
         module.warn(" ".join(stdErr.splitlines()[0:1]))
-        maintenanceMode = True
-    else:
-        maintenanceMode = False
 
     if "is not installed" in stdErr:
         module.warn(stdErr.splitlines()[0])
@@ -65,4 +62,4 @@ def run_occ(
             stderr=stdErr,
             command=command,
         )
-    return returnCode, stdOut, stdErr, maintenanceMode
+    return returnCode, stdOut, stdErr


### PR DESCRIPTION
I had Issues using the run_occ tasks with commands using parameters like `command: theming:config name "myNextcloud"`.

I tried to simplify the code to make it work with all occ commands.