### PR TITLE
fix run_occ regression to keep the '\' in parameters

### DIFF
--- a/plugins/module_utils/occ.py
+++ b/plugins/module_utils/occ.py
@@ -26,13 +26,12 @@
 import os
 from shlex import shlex
 
+
 def convert_string(command: str) -> list:
-    command_lex = shlex(command, posix=True)
+    command_lex = shlex(command, posix=False)
     command_lex.whitespace_split = True
-    if command.find("'") > 0:
-        command_lex.quotes = "'"
-    elif command.find('"') > 0:
-        command_lex.quotes = '"'
+    command_lex.escape = ""
+    command_lex.quotes = "\"'"
     return list(command_lex)
 
 def run_occ(

--- a/plugins/module_utils/occ.py
+++ b/plugins/module_utils/occ.py
@@ -30,9 +30,11 @@ from shlex import shlex
 def convert_string(command: str) -> list:
     command_lex = shlex(command, posix=False)
     command_lex.whitespace_split = True
+    command_lex.commenters = ""
     command_lex.escape = ""
     command_lex.quotes = "\"'"
-    return list(command_lex)
+    return [token if " " in token else token.strip("\"'") for token in command_lex]
+
 
 def run_occ(
     module,


### PR DESCRIPTION
slightly adjust "convert_string" function to avoid  '\\' be interpreted as an escape character
fixes #393 