### PR TITLE
Update tested Linux distributions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [debian12, debian11, ubuntu2204, ubuntu2004]
+        distro: [debian12, debian11, ubuntu2204, ubuntu2404]
         nc_version: [latest, nc28, nc27]
 
     steps:

--- a/.github/workflows/tests_latest.yml
+++ b/.github/workflows/tests_latest.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [debian12, debian11, ubuntu2204, ubuntu2004]
+        distro: [debian12, debian11, ubuntu2204, ubuntu2404]
         nc_version: [latest]
 
     steps:


### PR DESCRIPTION
Discontinue testing on Ubuntu 20.04 and add Ubuntu 24.04