### PR TITLE
removing deprecated tests of the app module inside the molecule test

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -36,10 +36,6 @@
         conf:
           var_1: "no"
       passwords:
-    nextcloud_disable_apps:
-      - photos
-      - external
-      - mail
   roles:
     - role: nextcloud.admin.install_nextcloud
   post_tasks:


### PR DESCRIPTION
reducing slightly the scope of the test in molecule because:
- app module is now unit tested with native ansible tool
- the "disable app" task fails regularly for external reasons (mostly lost of network access of the runner) requiring multiple manual retries and slowing down merges