### PR TITLE
Fix issue with new configuration variable max_memory_limit

### DIFF
--- a/roles/install_nextcloud/tasks/http_apache.yml
+++ b/roles/install_nextcloud/tasks/http_apache.yml
@@ -22,7 +22,7 @@
     - {regexp: 'opcache.memory_consumption', line: 'opcache.memory_consumption=128'}
     - {regexp: 'opcache.save_comments', line: 'opcache.save_comments=1'}
     - {regexp: 'opcache.revalidate_freq', line: 'opcache.revalidate_freq=1'}
-    - {regexp: 'memory_limit', line: 'memory_limit={{ php_memory_limit }}'}
+    - {regexp: '\bmemory_limit\b', line: 'memory_limit={{ php_memory_limit }}'}
     # validate: "/usr/sbin/{{ php_bin }} -t #%s"
   notify: Reload http
 

--- a/roles/install_nextcloud/tasks/http_nginx.yml
+++ b/roles/install_nextcloud/tasks/http_nginx.yml
@@ -44,7 +44,7 @@
     - { regexp: 'opcache.memory_consumption', line: 'opcache.memory_consumption=128' }
     - { regexp: 'opcache.save_comments', line: 'opcache.save_comments=1' }
     - { regexp: 'opcache.revalidate_freq', line: 'opcache.revalidate_freq=1' }
-    - { regexp: 'memory_limit', line: 'memory_limit={{ php_memory_limit }}'}
+    - { regexp: '\bmemory_limit\b', line: 'memory_limit={{ php_memory_limit }}'}
     # validate: "/usr/sbin/{{ php_bin }} -t #%s"
   notify: Reload php-fpm
 

--- a/roles/install_nextcloud/tasks/php_install.yml
+++ b/roles/install_nextcloud/tasks/php_install.yml
@@ -30,7 +30,7 @@
     backrefs: true
   with_items:
     - {regexp: 'opcache.interned_strings_buffer', line: 'opcache.interned_strings_buffer=16'}
-    - {regexp: 'memory_limit', line: 'memory_limit={{ php_memory_limit }}'}
+    - {regexp: '\bmemory_limit\b', line: 'memory_limit={{ php_memory_limit }}'}
   notify:
     - Start php-fpm
     - Reload http


### PR DESCRIPTION
PHP 8.5 introduces a new variable named `max_memory_limit`.

The regular expression used to set `memory_limit` also matches that new variable name and thus the wrong setting is overwritten.

By adding `\b` at the beginning and end of the regular expression the full variable name must match.